### PR TITLE
refactor: replace UUID database identifiers with bigint identity columns

### DIFF
--- a/apps/server/src/lib/auth.macros.ts
+++ b/apps/server/src/lib/auth.macros.ts
@@ -1,4 +1,5 @@
 import { auth } from '@repo/auth'
+import { normalizeAuthSession } from '@repo/auth/auth-session'
 import { db } from '@repo/db'
 import { AuthRole } from '@repo/db/types'
 import type { Role } from '@repo/db/types'
@@ -24,15 +25,18 @@ export const authMacro = new Elysia({ name: 'auth-macro' })
 	.use(logger)
 	.macro('auth', {
 		resolve: async function authMiddleware({ request: { headers }, log, statusError }) {
-			const session = await auth.api.getSession({ headers })
+			const rawSession = await auth.api.getSession({ headers })
 
-			if (!session || !AuthService.isValidAuthRole(session.user.role)) {
+			if (!rawSession || !AuthService.isValidAuthRole(rawSession.user.role)) {
 				return statusError(401, { message: 'You are not authenticated' })
 			}
 
+			const accountAgeDays = daysSince(rawSession.user.createdAt)
+			const session = normalizeAuthSession(rawSession)
+
 			log.set({
 				user: {
-					accountAgeDays: daysSince(session.user.createdAt),
+					accountAgeDays,
 					authRole: session.user.role,
 					id: session.user.id,
 				},
@@ -52,15 +56,18 @@ export const authMacro = new Elysia({ name: 'auth-macro' })
 
 	.macro('maybeAuth', {
 		resolve: async function maybeAuthMiddleware({ request: { headers }, log }) {
-			const session = await auth.api.getSession({ headers })
+			const rawSession = await auth.api.getSession({ headers })
 
-			if (!session || !AuthService.isValidAuthRole(session.user.role)) {
+			if (!rawSession || !AuthService.isValidAuthRole(rawSession.user.role)) {
 				return
 			}
 
+			const accountAgeDays = daysSince(rawSession.user.createdAt)
+			const session = normalizeAuthSession(rawSession)
+
 			log.set({
 				user: {
-					accountAgeDays: daysSince(session.user.createdAt),
+					accountAgeDays,
 					authRole: session.user.role,
 					id: session.user.id,
 				},
@@ -78,15 +85,18 @@ export const authMacro = new Elysia({ name: 'auth-macro' })
 
 	.macro('authAdmin', {
 		resolve: async function authAdminMiddleware({ request: { headers }, log, statusError }) {
-			const session = await auth.api.getSession({ headers })
+			const rawSession = await auth.api.getSession({ headers })
 
-			if (!session || !AuthService.isValidAuthRole(session.user.role)) {
+			if (!rawSession || !AuthService.isValidAuthRole(rawSession.user.role)) {
 				return statusError(401, { message: 'You are not authenticated' })
 			}
 
+			const accountAgeDays = daysSince(rawSession.user.createdAt)
+			const session = normalizeAuthSession(rawSession)
+
 			log.set({
 				user: {
-					accountAgeDays: daysSince(session.user.createdAt),
+					accountAgeDays,
 					authRole: session.user.role,
 					id: session.user.id,
 				},
@@ -104,17 +114,20 @@ export const authMacro = new Elysia({ name: 'auth-macro' })
 		'role',
 		(asked: Role | [Omit<Role, 'superadmin'> | [Omit<Role, 'superadmin'>], ...Role[]]) => ({
 			resolve: async function roleMiddleware({ request: { headers }, log, statusError }) {
-				const session = await auth.api.getSession({ headers })
+				const rawSession = await auth.api.getSession({ headers })
 
-				if (!session || !AuthService.isValidAuthRole(session.user.role)) {
+				if (!rawSession || !AuthService.isValidAuthRole(rawSession.user.role)) {
 					return statusError(401, { message: 'You are not authenticated' })
 				}
+
+				const accountAgeDays = daysSince(rawSession.user.createdAt)
+				const session = normalizeAuthSession(rawSession)
 
 				const userRoles = await db.query.userRoles.findMany({ where: { userId: session.user.id } })
 
 				log.set({
 					user: {
-						accountAgeDays: daysSince(session.user.createdAt),
+						accountAgeDays,
 						authRole: session.user.role,
 						id: session.user.id,
 						roles: userRoles.map((userRole) => userRole.role),

--- a/apps/server/src/modules/asset-lifecycle/asset-lifecycle.service.ts
+++ b/apps/server/src/modules/asset-lifecycle/asset-lifecycle.service.ts
@@ -1,7 +1,7 @@
 import type { DatabaseType, TransactionType } from '@repo/db'
 import { eq, inArray } from '@repo/db'
 import { assets, listingImages } from '@repo/db/schemas'
-import type { Asset, AssetInsert } from '@repo/db/types'
+import type { Asset, AssetInsert, Listing } from '@repo/db/types'
 import { fileStorage } from '@repo/file-storage'
 import { randomUUIDv7 } from 'bun'
 import { subDays } from 'date-fns'
@@ -24,9 +24,9 @@ type AssetLifecycleAdapters = {
 		create: () => string
 	}
 	listingImages: {
-		attach: (image: { assetId: Asset['id']; listingId: string }) => Promise<void>
-		detach?: (listingId: string) => Promise<Asset['id'][]>
-		replace?: (image: { assetId: Asset['id']; listingId: string }) => Promise<Asset['id'][]>
+		attach: (image: { assetId: Asset['id']; listingId: Listing['id'] }) => Promise<void>
+		detach?: (listingId: Listing['id']) => Promise<Asset['id'][]>
+		replace?: (image: { assetId: Asset['id']; listingId: Listing['id'] }) => Promise<Asset['id'][]>
 	}
 	storage: {
 		delete: (key: Asset['key']) => Promise<void>
@@ -47,7 +47,7 @@ type ReserveUploadInput = {
 
 type AttachListingImageInput = {
 	assetKey: Asset['key']
-	listingId: string
+	listingId: Listing['id']
 	ownerId: Asset['ownerId']
 }
 
@@ -122,7 +122,7 @@ export const AssetLifecycle = (adapters: AssetLifecycleAdapters) => ({
 		return { asset, url }
 	},
 
-	retireListingMedia: async ({ listingId }: { listingId: string }) => {
+	retireListingMedia: async ({ listingId }: { listingId: Listing['id'] }) => {
 		if (!adapters.listingImages.detach) {
 			throw new Error('Listing media retirement is not configured')
 		}
@@ -175,10 +175,10 @@ export const createAssetLifecycleAdapters = (db: DatabaseType | TransactionType)
 		create: () => randomUUIDv7(),
 	},
 	listingImages: {
-		attach: async ({ assetId, listingId }: { assetId: Asset['id']; listingId: string }) => {
+		attach: async ({ assetId, listingId }: { assetId: Asset['id']; listingId: Listing['id'] }) => {
 			await db.insert(listingImages).values({ assetId, listingId, sortOrder: 0 })
 		},
-		detach: async (listingId: string) => {
+		detach: async (listingId: Listing['id']) => {
 			const detachedImages = await db
 				.delete(listingImages)
 				.where(eq(listingImages.listingId, listingId))
@@ -186,7 +186,7 @@ export const createAssetLifecycleAdapters = (db: DatabaseType | TransactionType)
 
 			return detachedImages.map((image) => image.assetId)
 		},
-		replace: async ({ assetId, listingId }: { assetId: Asset['id']; listingId: string }) => {
+		replace: async ({ assetId, listingId }: { assetId: Asset['id']; listingId: Listing['id'] }) => {
 			const replacedImages = await db
 				.delete(listingImages)
 				.where(eq(listingImages.listingId, listingId))

--- a/apps/server/src/modules/listings/listings.controller.ts
+++ b/apps/server/src/modules/listings/listings.controller.ts
@@ -1,6 +1,7 @@
 import { db } from '@repo/db'
 import { listingInsertSchema, listingUpdateSchema } from '@repo/db/types'
 import { fileStorage } from '@repo/file-storage'
+import { coercePositiveInt } from '@repo/utils'
 import { Elysia } from 'elysia'
 import { z } from 'zod'
 
@@ -15,7 +16,7 @@ import {
 export const listingsRouter = new Elysia({ name: 'listings', tags: ['Listing'] })
 	.use(authMacro)
 
-	.model('uuidParam', z.object({ id: z.uuid() }))
+	.model('listingIdParam', z.object({ id: positiveIntParam('listing id') }))
 
 	.decorate('listingsService', ListingsService(db))
 
@@ -50,7 +51,7 @@ export const listingsRouter = new Elysia({ name: 'listings', tags: ['Listing'] }
 				throw error
 			}
 		},
-		{ auth: true, params: 'uuidParam' }
+		{ auth: true, params: 'listingIdParam' }
 	)
 
 	.post(
@@ -87,7 +88,7 @@ export const listingsRouter = new Elysia({ name: 'listings', tags: ['Listing'] }
 		{
 			auth: true,
 			body: listingUpdateSchema.extend({ imageKey: z.string().optional() }),
-			params: 'uuidParam',
+			params: 'listingIdParam',
 		}
 	)
 
@@ -109,7 +110,7 @@ export const listingsRouter = new Elysia({ name: 'listings', tags: ['Listing'] }
 				throw error
 			}
 		},
-		{ auth: true, params: 'uuidParam' }
+		{ auth: true, params: 'listingIdParam' }
 	)
 
 	.get(
@@ -131,4 +132,18 @@ function getImageUrl(imageKey: string | undefined | null) {
 	}
 
 	return fileStorage.getUrl(imageKey)
+}
+
+function positiveIntParam(label: string) {
+	return z.string().transform((value, ctx) => {
+		try {
+			return coercePositiveInt(value, label)
+		} catch (error) {
+			ctx.addIssue({
+				code: 'custom',
+				message: error instanceof Error ? error.message : `Invalid ${label}: ${value}`,
+			})
+			return z.NEVER
+		}
+	})
 }

--- a/apps/server/tests/admin-user-normalization.test.ts
+++ b/apps/server/tests/admin-user-normalization.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test'
+
+import { normalizeAdminUserList, stringifyAuthId } from '@repo/auth/admin-users'
+
+describe('admin user normalization', () => {
+	it('normalizes admin query ids for app code while preserving plugin fields', () => {
+		const [user] = normalizeAdminUserList([
+			{
+				banned: false,
+				createdAt: new Date(),
+				email: 'admin@test.com',
+				id: '7',
+				impersonatedBy: '3',
+				name: 'Admin',
+				role: 'admin',
+			},
+		])
+		if (!user) {
+			throw new Error('Expected normalized admin user')
+		}
+
+		expect(Number(user.id)).toBe(7)
+		expect(user.role).toBe('admin')
+		expect(user.impersonatedBy).toBe('3')
+	})
+
+	it('stringifies numeric ids at the Better Auth admin boundary', () => {
+		expect(stringifyAuthId(9)).toBe('9')
+		expect(stringifyAuthId('9')).toBe('9')
+	})
+})

--- a/apps/server/tests/asset-lifecycle.test.ts
+++ b/apps/server/tests/asset-lifecycle.test.ts
@@ -17,7 +17,7 @@ describe('Asset lifecycle', () => {
 						...asset,
 						createdAt: new Date(),
 						deletedAt: null,
-						id: 'asset-1',
+						id: 1,
 						updatedAt: new Date(),
 					}
 				},
@@ -79,7 +79,7 @@ describe('Asset lifecycle', () => {
 						...asset,
 						createdAt: new Date(),
 						deletedAt: null,
-						id: 'asset-1',
+						id: 1,
 						updatedAt: new Date(),
 					}
 				},
@@ -124,8 +124,8 @@ describe('Asset lifecycle', () => {
 	})
 
 	it('attaches a pending asset to a listing after upload verification', async () => {
-		const attachedImages: { assetId: string; listingId: number }[] = []
-		const updatedAssets: string[] = []
+		const attachedImages: { assetId: number; listingId: number }[] = []
+		const updatedAssets: number[] = []
 
 		const assetLifecycle = AssetLifecycle({
 			assets: {
@@ -148,7 +148,7 @@ describe('Asset lifecycle', () => {
 					...asset,
 					createdAt: new Date(),
 					deletedAt: null,
-					id: 'asset-1',
+					id: 1,
 					updatedAt: new Date(),
 				}),
 				delete: async () => {},
@@ -157,7 +157,7 @@ describe('Asset lifecycle', () => {
 					createdAt: new Date(),
 					deletedAt: null,
 					filename: 'photo.webp',
-					id: 'asset-1',
+					id: 1,
 					key: '1/upload-123.webp',
 					ownerId: 1,
 					size: 2048,
@@ -189,15 +189,15 @@ describe('Asset lifecycle', () => {
 		})
 
 		expect(asset.status).toBe('active')
-		expect(updatedAssets).toEqual(['asset-1'])
-		expect(attachedImages).toEqual([{ assetId: 'asset-1', listingId: 1 }])
+		expect(updatedAssets).toEqual([1])
+		expect(attachedImages).toEqual([{ assetId: 1, listingId: 1 }])
 	})
 
 	it('replaces a listing image through one lifecycle action', async () => {
-		const attachedImages: { assetId: string; listingId: number }[] = []
-		const replacedImages: { assetId: string; listingId: number }[] = []
-		const retiredAssetIds: string[] = []
-		const updatedAssets: string[] = []
+		const attachedImages: { assetId: number; listingId: number }[] = []
+		const replacedImages: { assetId: number; listingId: number }[] = []
+		const retiredAssetIds: number[] = []
+		const updatedAssets: number[] = []
 
 		const assetLifecycle = AssetLifecycle({
 			assets: {
@@ -220,7 +220,7 @@ describe('Asset lifecycle', () => {
 					...asset,
 					createdAt: new Date(),
 					deletedAt: null,
-					id: 'asset-created',
+					id: 999,
 					updatedAt: new Date(),
 				}),
 				delete: async () => {},
@@ -229,7 +229,7 @@ describe('Asset lifecycle', () => {
 					createdAt: new Date(),
 					deletedAt: null,
 					filename: 'new-photo.webp',
-					id: 'asset-2',
+					id: 2,
 					key: '1/upload-456.webp',
 					ownerId: 1,
 					size: 2048,
@@ -249,7 +249,7 @@ describe('Asset lifecycle', () => {
 				},
 				replace: async ({ assetId, listingId }) => {
 					replacedImages.push({ assetId, listingId })
-					return ['asset-1']
+					return [1]
 				},
 			},
 			storage: {
@@ -268,10 +268,10 @@ describe('Asset lifecycle', () => {
 		})
 
 		expect(asset.status).toBe('active')
-		expect(updatedAssets).toEqual(['asset-2'])
+		expect(updatedAssets).toEqual([2])
 		expect(attachedImages).toEqual([])
-		expect(replacedImages).toEqual([{ assetId: 'asset-2', listingId: 1 }])
-		expect(retiredAssetIds).toEqual(['asset-1'])
+		expect(replacedImages).toEqual([{ assetId: 2, listingId: 1 }])
+		expect(retiredAssetIds).toEqual([1])
 	})
 
 	it('rejects attaching an asset owned by another user', async () => {
@@ -287,7 +287,7 @@ describe('Asset lifecycle', () => {
 						createdAt: new Date(),
 						deletedAt: null,
 						filename: 'photo.webp',
-						id: 'asset-1',
+						id: 1,
 						key: '2/upload-123.webp',
 						ownerId: 2,
 						size: 2048,
@@ -299,7 +299,7 @@ describe('Asset lifecycle', () => {
 					...asset,
 					createdAt: new Date(),
 					deletedAt: null,
-					id: 'asset-1',
+					id: 1,
 					updatedAt: new Date(),
 				}),
 				delete: async () => {},
@@ -308,7 +308,7 @@ describe('Asset lifecycle', () => {
 					createdAt: new Date(),
 					deletedAt: null,
 					filename: 'photo.webp',
-					id: 'asset-1',
+					id: 1,
 					key: '2/upload-123.webp',
 					ownerId: 2,
 					size: 2048,
@@ -364,7 +364,7 @@ describe('Asset lifecycle', () => {
 					...asset,
 					createdAt: new Date(),
 					deletedAt: null,
-					id: 'asset-created',
+					id: 999,
 					updatedAt: new Date(),
 				}),
 				delete: async () => {},
@@ -382,7 +382,7 @@ describe('Asset lifecycle', () => {
 				},
 				replace: async () => {
 					replaced = true
-					return ['asset-1']
+					return [1]
 				},
 			},
 			storage: {
@@ -413,7 +413,7 @@ describe('Asset lifecycle', () => {
 	})
 
 	it('retires listing media through the asset lifecycle seam', async () => {
-		const retiredAssetIds: string[] = []
+		const retiredAssetIds: number[] = []
 		const detachedListingIds: number[] = []
 
 		const assetLifecycle = AssetLifecycle({
@@ -425,7 +425,7 @@ describe('Asset lifecycle', () => {
 					...asset,
 					createdAt: new Date(),
 					deletedAt: null,
-					id: 'asset-1',
+					id: 1,
 					updatedAt: new Date(),
 				}),
 				delete: async () => {},
@@ -443,7 +443,7 @@ describe('Asset lifecycle', () => {
 				},
 				detach: async (listingId) => {
 					detachedListingIds.push(listingId)
-					return ['asset-1']
+					return [1]
 				},
 			},
 			storage: {
@@ -457,13 +457,13 @@ describe('Asset lifecycle', () => {
 
 		const result = await assetLifecycle.retireListingMedia({ listingId: 1 })
 
-		expect(result.retiredAssetIds).toEqual(['asset-1'])
+		expect(result.retiredAssetIds).toEqual([1])
 		expect(detachedListingIds).toEqual([1])
-		expect(retiredAssetIds).toEqual(['asset-1'])
+		expect(retiredAssetIds).toEqual([1])
 	})
 
 	it('cleans up stale pending assets through the asset lifecycle seam', async () => {
-		const deletedAssetIds: string[] = []
+		const deletedAssetIds: number[] = []
 		const deletedStorageKeys: string[] = []
 
 		const assetLifecycle = AssetLifecycle({
@@ -475,10 +475,10 @@ describe('Asset lifecycle', () => {
 					...asset,
 					createdAt: new Date(),
 					deletedAt: null,
-					id: 'asset-1',
+					id: 1,
 					updatedAt: new Date(),
 				}),
-				delete: async (ids: string[]) => {
+				delete: async (ids) => {
 					deletedAssetIds.push(...ids)
 				},
 				findPendingByKey: async () => null,
@@ -488,7 +488,7 @@ describe('Asset lifecycle', () => {
 						createdAt: new Date('2026-04-27T10:00:00.000Z'),
 						deletedAt: null,
 						filename: 'photo.webp',
-						id: 'asset-1',
+						id: 1,
 						key: '1/stale.webp',
 						ownerId: 1,
 						size: 2048,
@@ -521,11 +521,11 @@ describe('Asset lifecycle', () => {
 
 		expect(result.filesDeleted).toBe(1)
 		expect(deletedStorageKeys).toEqual(['1/stale.webp'])
-		expect(deletedAssetIds).toEqual(['asset-1'])
+		expect(deletedAssetIds).toEqual([1])
 	})
 
 	it('removes stale pending assets even when the blob is already missing', async () => {
-		const deletedAssetIds: string[] = []
+		const deletedAssetIds: number[] = []
 		let storageDeleteCalls = 0
 
 		const assetLifecycle = AssetLifecycle({
@@ -537,10 +537,10 @@ describe('Asset lifecycle', () => {
 					...asset,
 					createdAt: new Date(),
 					deletedAt: null,
-					id: 'asset-1',
+					id: 1,
 					updatedAt: new Date(),
 				}),
-				delete: async (ids: string[]) => {
+				delete: async (ids) => {
 					deletedAssetIds.push(...ids)
 				},
 				findPendingByKey: async () => null,
@@ -550,7 +550,7 @@ describe('Asset lifecycle', () => {
 						createdAt: new Date('2026-04-27T10:00:00.000Z'),
 						deletedAt: null,
 						filename: 'photo.webp',
-						id: 'asset-1',
+						id: 1,
 						key: '1/missing.webp',
 						ownerId: 1,
 						size: 2048,
@@ -583,11 +583,11 @@ describe('Asset lifecycle', () => {
 
 		expect(result.filesDeleted).toBe(1)
 		expect(storageDeleteCalls).toBe(0)
-		expect(deletedAssetIds).toEqual(['asset-1'])
+		expect(deletedAssetIds).toEqual([1])
 	})
 
 	it('is idempotent across repeated stale cleanup runs', async () => {
-		const deletedAssetIds: string[] = []
+		const deletedAssetIds: number[] = []
 		const deletedStorageKeys: string[] = []
 		const staleAssets = [
 			{
@@ -595,7 +595,7 @@ describe('Asset lifecycle', () => {
 				createdAt: new Date('2026-04-27T10:00:00.000Z'),
 				deletedAt: null,
 				filename: 'photo.webp',
-				id: 'asset-1',
+				id: 1,
 				key: '1/stale.webp',
 				ownerId: 1,
 				size: 2048,
@@ -613,10 +613,10 @@ describe('Asset lifecycle', () => {
 					...asset,
 					createdAt: new Date(),
 					deletedAt: null,
-					id: 'asset-1',
+					id: 1,
 					updatedAt: new Date(),
 				}),
-				delete: async (ids: string[]) => {
+				delete: async (ids) => {
 					deletedAssetIds.push(...ids)
 					for (const id of ids) {
 						const index = staleAssets.findIndex((asset) => asset.id === id)
@@ -654,6 +654,6 @@ describe('Asset lifecycle', () => {
 		expect(firstRun.filesDeleted).toBe(1)
 		expect(secondRun.filesDeleted).toBe(0)
 		expect(deletedStorageKeys).toEqual(['1/stale.webp'])
-		expect(deletedAssetIds).toEqual(['asset-1'])
+		expect(deletedAssetIds).toEqual([1])
 	})
 })

--- a/apps/server/tests/asset-lifecycle.test.ts
+++ b/apps/server/tests/asset-lifecycle.test.ts
@@ -124,7 +124,7 @@ describe('Asset lifecycle', () => {
 	})
 
 	it('attaches a pending asset to a listing after upload verification', async () => {
-		const attachedImages: Record<string, string>[] = []
+		const attachedImages: { assetId: string; listingId: number }[] = []
 		const updatedAssets: string[] = []
 
 		const assetLifecycle = AssetLifecycle({
@@ -184,18 +184,18 @@ describe('Asset lifecycle', () => {
 
 		const asset = await assetLifecycle.attachListingImage({
 			assetKey: '1/upload-123.webp',
-			listingId: 'listing-1',
+			listingId: 1,
 			ownerId: 1,
 		})
 
 		expect(asset.status).toBe('active')
 		expect(updatedAssets).toEqual(['asset-1'])
-		expect(attachedImages).toEqual([{ assetId: 'asset-1', listingId: 'listing-1' }])
+		expect(attachedImages).toEqual([{ assetId: 'asset-1', listingId: 1 }])
 	})
 
 	it('replaces a listing image through one lifecycle action', async () => {
-		const attachedImages: Record<string, string>[] = []
-		const replacedImages: Record<string, string>[] = []
+		const attachedImages: { assetId: string; listingId: number }[] = []
+		const replacedImages: { assetId: string; listingId: number }[] = []
 		const retiredAssetIds: string[] = []
 		const updatedAssets: string[] = []
 
@@ -263,14 +263,14 @@ describe('Asset lifecycle', () => {
 
 		const asset = await assetLifecycle.replaceListingImage({
 			assetKey: '1/upload-456.webp',
-			listingId: 'listing-1',
+			listingId: 1,
 			ownerId: 1,
 		})
 
 		expect(asset.status).toBe('active')
 		expect(updatedAssets).toEqual(['asset-2'])
 		expect(attachedImages).toEqual([])
-		expect(replacedImages).toEqual([{ assetId: 'asset-2', listingId: 'listing-1' }])
+		expect(replacedImages).toEqual([{ assetId: 'asset-2', listingId: 1 }])
 		expect(retiredAssetIds).toEqual(['asset-1'])
 	})
 
@@ -336,7 +336,7 @@ describe('Asset lifecycle', () => {
 		try {
 			await assetLifecycle.attachListingImage({
 				assetKey: '2/upload-123.webp',
-				listingId: 'listing-1',
+				listingId: 1,
 				ownerId: 1,
 			})
 			throw new Error('Expected attachListingImage to reject')
@@ -397,7 +397,7 @@ describe('Asset lifecycle', () => {
 		try {
 			await assetLifecycle.replaceListingImage({
 				assetKey: '1/missing.webp',
-				listingId: 'listing-1',
+				listingId: 1,
 				ownerId: 1,
 			})
 			throw new Error('Expected replaceListingImage to reject')
@@ -414,7 +414,7 @@ describe('Asset lifecycle', () => {
 
 	it('retires listing media through the asset lifecycle seam', async () => {
 		const retiredAssetIds: string[] = []
-		const detachedListingIds: string[] = []
+		const detachedListingIds: number[] = []
 
 		const assetLifecycle = AssetLifecycle({
 			assets: {
@@ -455,10 +455,10 @@ describe('Asset lifecycle', () => {
 			},
 		})
 
-		const result = await assetLifecycle.retireListingMedia({ listingId: 'listing-1' })
+		const result = await assetLifecycle.retireListingMedia({ listingId: 1 })
 
 		expect(result.retiredAssetIds).toEqual(['asset-1'])
-		expect(detachedListingIds).toEqual(['listing-1'])
+		expect(detachedListingIds).toEqual([1])
 		expect(retiredAssetIds).toEqual(['asset-1'])
 	})
 

--- a/apps/server/tests/asset-lifecycle.test.ts
+++ b/apps/server/tests/asset-lifecycle.test.ts
@@ -44,21 +44,21 @@ describe('Asset lifecycle', () => {
 		const reservation = await assetLifecycle.reserveUpload({
 			contentType: 'image/webp',
 			filename: 'photo.webp',
-			ownerId: 'user-1',
+			ownerId: 1,
 			public: true,
 			size: 2048,
 		})
 
-		expect(reservation.url).toBe('https://upload.test/user-1/upload-123.webp?public=true')
-		expect(reservation.asset.ownerId).toBe('user-1')
-		expect(reservation.asset.key).toBe('user-1/upload-123.webp')
+		expect(reservation.url).toBe('https://upload.test/1/upload-123.webp?public=true')
+		expect(reservation.asset.ownerId).toBe(1)
+		expect(reservation.asset.key).toBe('1/upload-123.webp')
 		expect(reservation.asset.status).toBe('pending')
 		expect(createdAssets).toEqual([
 			{
 				contentType: 'image/webp',
 				filename: 'photo.webp',
-				key: 'user-1/upload-123.webp',
-				ownerId: 'user-1',
+				key: '1/upload-123.webp',
+				ownerId: 1,
 				size: 2048,
 				status: 'pending',
 			},
@@ -109,7 +109,7 @@ describe('Asset lifecycle', () => {
 			await assetLifecycle.reserveUpload({
 				contentType: 'image/webp',
 				filename: 'photo.webp',
-				ownerId: 'user-1',
+				ownerId: 1,
 				size: 2048,
 			})
 			throw new Error('Expected upload reservation to fail')
@@ -137,8 +137,8 @@ describe('Asset lifecycle', () => {
 						deletedAt: null,
 						filename: 'photo.webp',
 						id,
-						key: 'user-1/upload-123.webp',
-						ownerId: 'user-1',
+						key: '1/upload-123.webp',
+						ownerId: 1,
 						size: 2048,
 						status: 'active',
 						updatedAt: new Date(),
@@ -158,8 +158,8 @@ describe('Asset lifecycle', () => {
 					deletedAt: null,
 					filename: 'photo.webp',
 					id: 'asset-1',
-					key: 'user-1/upload-123.webp',
-					ownerId: 'user-1',
+					key: '1/upload-123.webp',
+					ownerId: 1,
 					size: 2048,
 					status: 'pending',
 					updatedAt: new Date(),
@@ -183,9 +183,9 @@ describe('Asset lifecycle', () => {
 		})
 
 		const asset = await assetLifecycle.attachListingImage({
-			assetKey: 'user-1/upload-123.webp',
+			assetKey: '1/upload-123.webp',
 			listingId: 'listing-1',
-			ownerId: 'user-1',
+			ownerId: 1,
 		})
 
 		expect(asset.status).toBe('active')
@@ -209,8 +209,8 @@ describe('Asset lifecycle', () => {
 						deletedAt: null,
 						filename: 'new-photo.webp',
 						id,
-						key: 'user-1/upload-456.webp',
-						ownerId: 'user-1',
+						key: '1/upload-456.webp',
+						ownerId: 1,
 						size: 2048,
 						status: 'active',
 						updatedAt: new Date(),
@@ -230,8 +230,8 @@ describe('Asset lifecycle', () => {
 					deletedAt: null,
 					filename: 'new-photo.webp',
 					id: 'asset-2',
-					key: 'user-1/upload-456.webp',
-					ownerId: 'user-1',
+					key: '1/upload-456.webp',
+					ownerId: 1,
 					size: 2048,
 					status: 'pending',
 					updatedAt: new Date(),
@@ -262,9 +262,9 @@ describe('Asset lifecycle', () => {
 		})
 
 		const asset = await assetLifecycle.replaceListingImage({
-			assetKey: 'user-1/upload-456.webp',
+			assetKey: '1/upload-456.webp',
 			listingId: 'listing-1',
-			ownerId: 'user-1',
+			ownerId: 1,
 		})
 
 		expect(asset.status).toBe('active')
@@ -288,8 +288,8 @@ describe('Asset lifecycle', () => {
 						deletedAt: null,
 						filename: 'photo.webp',
 						id: 'asset-1',
-						key: 'user-2/upload-123.webp',
-						ownerId: 'user-2',
+						key: '2/upload-123.webp',
+						ownerId: 2,
 						size: 2048,
 						status: 'active',
 						updatedAt: new Date(),
@@ -309,8 +309,8 @@ describe('Asset lifecycle', () => {
 					deletedAt: null,
 					filename: 'photo.webp',
 					id: 'asset-1',
-					key: 'user-2/upload-123.webp',
-					ownerId: 'user-2',
+					key: '2/upload-123.webp',
+					ownerId: 2,
 					size: 2048,
 					status: 'pending',
 					updatedAt: new Date(),
@@ -335,9 +335,9 @@ describe('Asset lifecycle', () => {
 
 		try {
 			await assetLifecycle.attachListingImage({
-				assetKey: 'user-2/upload-123.webp',
+				assetKey: '2/upload-123.webp',
 				listingId: 'listing-1',
-				ownerId: 'user-1',
+				ownerId: 1,
 			})
 			throw new Error('Expected attachListingImage to reject')
 		} catch (error) {
@@ -396,9 +396,9 @@ describe('Asset lifecycle', () => {
 
 		try {
 			await assetLifecycle.replaceListingImage({
-				assetKey: 'user-1/missing.webp',
+				assetKey: '1/missing.webp',
 				listingId: 'listing-1',
-				ownerId: 'user-1',
+				ownerId: 1,
 			})
 			throw new Error('Expected replaceListingImage to reject')
 		} catch (error) {
@@ -489,8 +489,8 @@ describe('Asset lifecycle', () => {
 						deletedAt: null,
 						filename: 'photo.webp',
 						id: 'asset-1',
-						key: 'user-1/stale.webp',
-						ownerId: 'user-1',
+						key: '1/stale.webp',
+						ownerId: 1,
 						size: 2048,
 						status: 'pending',
 						updatedAt: new Date('2026-04-27T10:00:00.000Z'),
@@ -520,7 +520,7 @@ describe('Asset lifecycle', () => {
 		const result = await assetLifecycle.cleanupStalePendingAssets()
 
 		expect(result.filesDeleted).toBe(1)
-		expect(deletedStorageKeys).toEqual(['user-1/stale.webp'])
+		expect(deletedStorageKeys).toEqual(['1/stale.webp'])
 		expect(deletedAssetIds).toEqual(['asset-1'])
 	})
 
@@ -551,8 +551,8 @@ describe('Asset lifecycle', () => {
 						deletedAt: null,
 						filename: 'photo.webp',
 						id: 'asset-1',
-						key: 'user-1/missing.webp',
-						ownerId: 'user-1',
+						key: '1/missing.webp',
+						ownerId: 1,
 						size: 2048,
 						status: 'pending',
 						updatedAt: new Date('2026-04-27T10:00:00.000Z'),
@@ -596,8 +596,8 @@ describe('Asset lifecycle', () => {
 				deletedAt: null,
 				filename: 'photo.webp',
 				id: 'asset-1',
-				key: 'user-1/stale.webp',
-				ownerId: 'user-1',
+				key: '1/stale.webp',
+				ownerId: 1,
 				size: 2048,
 				status: 'pending' as const,
 				updatedAt: new Date('2026-04-27T10:00:00.000Z'),
@@ -653,7 +653,7 @@ describe('Asset lifecycle', () => {
 
 		expect(firstRun.filesDeleted).toBe(1)
 		expect(secondRun.filesDeleted).toBe(0)
-		expect(deletedStorageKeys).toEqual(['user-1/stale.webp'])
+		expect(deletedStorageKeys).toEqual(['1/stale.webp'])
 		expect(deletedAssetIds).toEqual(['asset-1'])
 	})
 })

--- a/apps/server/tests/auth-session.test.ts
+++ b/apps/server/tests/auth-session.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'bun:test'
+
+import { normalizeAuthSession } from '@repo/auth/auth-session'
+
+describe('auth session normalization', () => {
+	it('normalizes numeric ids including impersonation metadata', () => {
+		const auth = normalizeAuthSession({
+			session: {
+				expiresAt: new Date(),
+				id: '9',
+				impersonatedBy: '3',
+				token: 'token',
+				userId: '4',
+			},
+			user: {
+				createdAt: new Date(),
+				email: 'user@test.com',
+				id: '4',
+				role: 'admin',
+			},
+		})
+
+		expect(auth.user.id).toBe(4)
+		expect(auth.session.id).toBe(9)
+		expect(auth.session.userId).toBe(4)
+		expect(auth.session.impersonatedBy).toBe(3)
+	})
+})

--- a/apps/server/tests/files.test.ts
+++ b/apps/server/tests/files.test.ts
@@ -58,6 +58,7 @@ describe('Files', () => {
 				size: 512,
 			})
 
+			expect(res.data?.asset?.id).toBeNumber()
 			expect(res.data?.asset?.ownerId).toBe(testUsers.user.id)
 		})
 

--- a/apps/server/tests/files.test.ts
+++ b/apps/server/tests/files.test.ts
@@ -12,6 +12,12 @@ describe('Files', () => {
 	let adminApi: Awaited<ReturnType<typeof createApiWithAuth>>['api']
 	let userApi: Awaited<ReturnType<typeof createApiWithAuth>>['api']
 
+	const grantRole = (values: {
+		grantedById?: number | null
+		role: 'admin' | 'superadmin' | 'user'
+		userId: number
+	}) => db.insert(userRoles).values(values)
+
 	beforeEach(async () => {
 		await createTestUsers()
 		adminApi = (await createApiWithAuth(testUsers.admin)).api
@@ -123,13 +129,19 @@ describe('Files', () => {
 			expect(res.status).toBe(401)
 		})
 
-		it('returns 403 for non-superadmin', async () => {
-			const res = await userApi.files.cleanup.get()
-			expect([401, 403]).toContain(res.status)
+		it('returns 403 for authenticated users without the required numeric role assignment', async () => {
+			await grantRole({
+				grantedById: testUsers.admin.id,
+				role: 'admin',
+				userId: testUsers.admin.id,
+			})
+
+			const res = await adminApi.files.cleanup.get()
+			expect(res.status).toBe(403)
 		})
 
 		it('cleans up stale pending assets end to end for superadmins', async () => {
-			await db.insert(userRoles).values({
+			await grantRole({
 				grantedById: testUsers.admin.id,
 				role: 'superadmin',
 				userId: testUsers.admin.id,

--- a/apps/server/tests/global.test.ts
+++ b/apps/server/tests/global.test.ts
@@ -41,11 +41,17 @@ describe('Global', () => {
 
 		expect(adminMeResponse.status).toBe(200)
 		expect(adminMeResponse.data?.user?.id).toBe(testUsers.admin.id)
+		expect(typeof adminMeResponse.data?.user?.id).toBe('number')
+		expect(typeof adminMeResponse.data?.session.id).toBe('number')
+		expect(typeof adminMeResponse.data?.session.userId).toBe('number')
 
 		const normalApi = (await createApiWithAuth(testUsers.user)).api
 		const normalMeResponse = await normalApi.me.get()
 
 		expect(normalMeResponse.status).toBe(200)
 		expect(normalMeResponse.data?.user?.id).toBe(testUsers.user.id)
+		expect(typeof normalMeResponse.data?.user?.id).toBe('number')
+		expect(typeof normalMeResponse.data?.session.id).toBe('number')
+		expect(typeof normalMeResponse.data?.session.userId).toBe('number')
 	})
 })

--- a/apps/server/tests/listings.test.ts
+++ b/apps/server/tests/listings.test.ts
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, it } from 'bun:test'
 import { db } from '@repo/db'
 import { listings } from '@repo/db/schemas'
 import { fileStorageMock } from '@repo/file-storage/test'
-import { randomUUIDv7 } from 'bun'
 
 import { createApi, createApiWithAuth, createTestUsers, testUsers } from './utils'
 
@@ -98,8 +97,13 @@ describe('Listings', () => {
 			expect(res.data?.image).toBeString()
 		})
 
+		it('rejects invalid numeric route params at the boundary', async () => {
+			const res = await userApi.listings({ id: '0' }).get()
+			expect(res.status).toBe(422)
+		})
+
 		it('returns 404 for nonexistent id', async () => {
-			const res = await userApi.listings({ id: randomUUIDv7() }).get()
+			const res = await userApi.listings({ id: 999_999 }).get()
 			expect(res.status).toBe(404)
 		})
 	})
@@ -112,6 +116,7 @@ describe('Listings', () => {
 			const res = await userApi.listings.post({ ...validListing, imageKey })
 
 			expect(res.status).toBe(201)
+			expect(res.data?.id).toBeNumber()
 			expect(res.data?.title).toBe(validListing.title)
 			expect(res.data?.price).toBe(validListing.price)
 		})
@@ -156,7 +161,7 @@ describe('Listings', () => {
 		})
 
 		it('returns 404 for nonexistent id', async () => {
-			const res = await userApi.listings({ id: randomUUIDv7() }).patch({ title: 'Nope' })
+			const res = await userApi.listings({ id: 999_999 }).patch({ title: 'Nope' })
 			expect(res.status).toBe(404)
 		})
 
@@ -227,7 +232,7 @@ describe('Listings', () => {
 		})
 
 		it('returns 404 for nonexistent id', async () => {
-			const res = await userApi.listings({ id: randomUUIDv7() }).delete()
+			const res = await userApi.listings({ id: 999_999 }).delete()
 			expect(res.status).toBe(404)
 		})
 	})

--- a/apps/server/tests/listings.test.ts
+++ b/apps/server/tests/listings.test.ts
@@ -102,6 +102,11 @@ describe('Listings', () => {
 			expect(res.status).toBe(422)
 		})
 
+		it('rejects non-decimal numeric route params at the boundary', async () => {
+			const res = await userApi.listings({ id: '1e2' }).get()
+			expect(res.status).toBe(422)
+		})
+
 		it('returns 404 for nonexistent id', async () => {
 			const res = await userApi.listings({ id: 999_999 }).get()
 			expect(res.status).toBe(404)

--- a/apps/server/tests/listings.test.ts
+++ b/apps/server/tests/listings.test.ts
@@ -121,6 +121,23 @@ describe('Listings', () => {
 			expect(res.data?.price).toBe(validListing.price)
 		})
 
+		it('stores numeric asset ownership and listing-media relation ids', async () => {
+			const imageKey = await presignImage(userApi)
+			const res = await userApi.listings.post({ ...validListing, imageKey })
+
+			const asset = await db.query.assets.findFirst({ where: { key: imageKey } })
+			const relation = await db.query.listingImages.findFirst({
+				where: { listingId: res.data!.id },
+			})
+
+			expect(asset).toBeDefined()
+			expect(asset?.id).toBeNumber()
+			expect(asset?.ownerId).toBe(testUsers.user.id)
+			expect(relation).toBeDefined()
+			expect(relation?.assetId).toBe(asset?.id)
+			expect(relation?.listingId).toBe(res.data?.id)
+		})
+
 		it('validates required fields', async () => {
 			// @ts-expect-error - intentionally missing fields
 			const res = await userApi.listings.post({})

--- a/apps/server/tests/numeric-id.test.ts
+++ b/apps/server/tests/numeric-id.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test'
+
+import { coercePositiveInt, normalizeOptionalPositiveInt } from '@repo/utils'
+
+describe('numeric id helpers', () => {
+	it('coerces positive integer inputs and preserves nullish optional values', () => {
+		expect(coercePositiveInt('9')).toBe(9)
+		expect(coercePositiveInt(4)).toBe(4)
+		expect(normalizeOptionalPositiveInt('3')).toBe(3)
+		expect(normalizeOptionalPositiveInt(null)).toBeNull()
+		expect(normalizeOptionalPositiveInt()).toBeUndefined()
+	})
+
+	it('rejects non-positive and non-integer values', () => {
+		expect(() => coercePositiveInt('0', 'listing id')).toThrow('Invalid listing id: 0')
+		expect(() => coercePositiveInt('4.2', 'listing id')).toThrow('Invalid listing id: 4.2')
+	})
+})

--- a/apps/server/tests/numeric-id.test.ts
+++ b/apps/server/tests/numeric-id.test.ts
@@ -15,4 +15,10 @@ describe('numeric id helpers', () => {
 		expect(() => coercePositiveInt('0', 'listing id')).toThrow('Invalid listing id: 0')
 		expect(() => coercePositiveInt('4.2', 'listing id')).toThrow('Invalid listing id: 4.2')
 	})
+
+	it('rejects non-decimal string coercions', () => {
+		expect(() => coercePositiveInt('1e2', 'listing id')).toThrow('Invalid listing id: 1e2')
+		expect(() => coercePositiveInt('0x10', 'listing id')).toThrow('Invalid listing id: 0x10')
+		expect(() => coercePositiveInt(' 7 ', 'listing id')).toThrow('Invalid listing id:  7 ')
+	})
 })

--- a/apps/server/tests/numeric-id.test.ts
+++ b/apps/server/tests/numeric-id.test.ts
@@ -8,7 +8,8 @@ describe('numeric id helpers', () => {
 		expect(coercePositiveInt(4)).toBe(4)
 		expect(normalizeOptionalPositiveInt('3')).toBe(3)
 		expect(normalizeOptionalPositiveInt(null)).toBeNull()
-		expect(normalizeOptionalPositiveInt()).toBeUndefined()
+		// oxlint-disable-next-line unicorn/no-useless-undefined
+		expect(normalizeOptionalPositiveInt(undefined)).toBeUndefined()
 	})
 
 	it('rejects non-positive and non-integer values', () => {

--- a/apps/server/tests/utils.ts
+++ b/apps/server/tests/utils.ts
@@ -1,24 +1,25 @@
 import { treaty } from '@elysiajs/eden'
 import { auth } from '@repo/auth'
+import { normalizeAuthId } from '@repo/auth/auth-session'
 import { db } from '@repo/db'
 import type { AuthRole } from '@repo/db/types'
 import { typedObjectEntries } from '@repo/utils'
 
 import { app } from '../src/api'
 
-type TestUser = { id: string; email: string; name: string; role: AuthRole; password: string }
+type TestUser = { id: number; email: string; name: string; role: AuthRole; password: string }
 
 export const testUsers: Record<'admin' | 'user', TestUser> = {
 	admin: {
 		email: 'admin@test.com',
-		id: '1',
+		id: 1,
 		name: 'Admin',
 		password: 'test-admin-password',
 		role: 'admin',
 	},
 	user: {
 		email: 'user@test.com',
-		id: '2',
+		id: 2,
 		name: 'User',
 		password: 'test-user-password',
 		role: 'user',
@@ -49,15 +50,16 @@ export const createTestUsers = async () => {
 	const existingUsers = await db.query.users.findMany()
 
 	await Promise.all(
-		typedObjectEntries(testUsers).map(async ([_, value]) => {
+		typedObjectEntries(testUsers).map(async ([, value]) => {
 			const existingUser = existingUsers.find((u) => u.email === value.email)
 			if (existingUser) {
-				value.id = existingUser.id
+				value.id = normalizeAuthId(existingUser.id)
 			} else {
+				const { id: _, ...input } = value
 				const { user } = await auth.api.createUser({
-					body: value,
+					body: input,
 				})
-				value.id = user.id
+				value.id = normalizeAuthId(user.id)
 			}
 		})
 	)

--- a/apps/web/src/components/routes/admin/dialogs/ban-user-dialog.tsx
+++ b/apps/web/src/components/routes/admin/dialogs/ban-user-dialog.tsx
@@ -22,6 +22,8 @@ import {
 import { authClient } from '~/lib/clients/auth-client'
 import type { UserWithRole } from '~/lib/queries/admin.queries'
 
+import { stringifyAuthId } from '../../../../../../../packages/auth/src/admin-users'
+
 // Ban duration options in seconds
 const BAN_DURATIONS = [
 	{ label: '1 Hour', value: 60 * 60 },
@@ -58,7 +60,7 @@ export function BanUserDialog({ user, open, onOpenChange, onSuccess }: Props) {
 			// 0 = permanent ban (no expiry)
 			banExpiresIn: banDuration === 0 ? undefined : banDuration,
 			banReason: banReason || undefined,
-			userId: user.id,
+			userId: stringifyAuthId(user.id),
 		})
 
 		setIsSubmitting(false)
@@ -78,7 +80,7 @@ export function BanUserDialog({ user, open, onOpenChange, onSuccess }: Props) {
 		setIsSubmitting(true)
 
 		const result = await authClient.admin.unbanUser({
-			userId: user.id,
+			userId: stringifyAuthId(user.id),
 		})
 
 		setIsSubmitting(false)

--- a/apps/web/src/components/routes/admin/dialogs/change-password-dialog.tsx
+++ b/apps/web/src/components/routes/admin/dialogs/change-password-dialog.tsx
@@ -13,13 +13,11 @@ import {
 } from '~/components/ui/dialog'
 import { authClient } from '~/lib/clients/auth-client'
 import { useAppForm } from '~/lib/hooks/form-hook'
+import type { UserWithRole } from '~/lib/queries/admin.queries'
 
-// User type matching the admin API response
-type AdminUser = {
-	id: string
-	name: string
-	email: string
-}
+import { stringifyAuthId } from '../../../../../../../packages/auth/src/admin-users'
+
+type AdminUser = Pick<UserWithRole, 'email' | 'id' | 'name'>
 
 type Props = {
 	user: AdminUser
@@ -48,7 +46,7 @@ export function ChangePasswordDialog({ user, open, onOpenChange, onSuccess }: Pr
 
 			const result = await authClient.admin.setUserPassword({
 				newPassword: value.newPassword,
-				userId: user.id,
+				userId: stringifyAuthId(user.id),
 			})
 
 			setIsSubmitting(false)

--- a/apps/web/src/components/routes/admin/dialogs/change-role-dialog.tsx
+++ b/apps/web/src/components/routes/admin/dialogs/change-role-dialog.tsx
@@ -22,6 +22,8 @@ import {
 import { authClient } from '~/lib/clients/auth-client'
 import type { UserWithRole } from '~/lib/queries/admin.queries'
 
+import { stringifyAuthId } from '../../../../../../../packages/auth/src/admin-users'
+
 type Props = {
 	user: UserWithRole
 	open: boolean
@@ -44,7 +46,7 @@ export function ChangeRoleDialog({ user, open, onOpenChange, onSuccess }: Props)
 
 		const result = await authClient.admin.setRole({
 			role: selectedRole,
-			userId: user.id,
+			userId: stringifyAuthId(user.id),
 		})
 
 		setIsSubmitting(false)

--- a/apps/web/src/components/routes/admin/dialogs/impersonate-confirm-dialog.tsx
+++ b/apps/web/src/components/routes/admin/dialogs/impersonate-confirm-dialog.tsx
@@ -14,6 +14,8 @@ import {
 import { authClient } from '~/lib/clients/auth-client'
 import type { UserWithRole } from '~/lib/queries/admin.queries'
 
+import { stringifyAuthId } from '../../../../../../../packages/auth/src/admin-users'
+
 type Props = {
 	user: UserWithRole
 	open: boolean
@@ -27,7 +29,7 @@ export function ImpersonateConfirmDialog({ user, open, onOpenChange }: Props) {
 		setIsSubmitting(true)
 
 		const result = await authClient.admin.impersonateUser({
-			userId: user.id,
+			userId: stringifyAuthId(user.id),
 		})
 
 		setIsSubmitting(false)

--- a/apps/web/src/components/routes/admin/users-table.tsx
+++ b/apps/web/src/components/routes/admin/users-table.tsx
@@ -33,6 +33,21 @@ import { ImpersonateConfirmDialog } from './dialogs/impersonate-confirm-dialog'
 
 const columns: ColumnDef<UserWithRole>[] = [
 	{
+		accessorKey: 'id',
+		cell: ({ row }) => <span className="font-mono text-sm">{row.original.id}</span>,
+		header: ({ column }) => (
+			<Button
+				onClick={() => {
+					column.toggleSorting(column.getIsSorted() === 'asc')
+				}}
+				variant="ghost"
+			>
+				ID
+				<ArrowUpDown className="ml-2 size-4" />
+			</Button>
+		),
+	},
+	{
 		accessorKey: 'name',
 		cell: ({ row }) => (
 			<div className="flex items-center gap-2">

--- a/apps/web/src/lib/mutations/listings.mutations.ts
+++ b/apps/web/src/lib/mutations/listings.mutations.ts
@@ -2,13 +2,13 @@ import { keys } from '~/lib/queries/keys'
 import { eden } from '~/lib/server-fn/eden'
 import { edenMutationOption } from '~/lib/utils/eden-query'
 
-export const deleteListingOptions = (id: string) =>
+export const deleteListingOptions = (id: number) =>
 	edenMutationOption({
 		edenMutation: eden().listings({ id }).delete,
 		meta: { invalidate: [keys.listings.all] },
 	})
 
-export const updateListingOptions = (id: string) =>
+export const updateListingOptions = (id: number) =>
 	edenMutationOption({
 		edenMutation: eden().listings({ id }).patch,
 		meta: { invalidate: [keys.listings.all] },

--- a/apps/web/src/lib/queries/admin.queries.ts
+++ b/apps/web/src/lib/queries/admin.queries.ts
@@ -1,10 +1,11 @@
-import type { AuthRole } from '@repo/db/types'
 import type { Prettify } from '@repo/utils'
 import { queryOptions } from '@tanstack/react-query'
 import type { UserWithRole as BetterAuthUserWithRole } from 'better-auth/plugins'
 
 import { authClient } from '~/lib/clients/auth-client'
 
+import { normalizeAdminUserList } from '../../../../../packages/auth/src/admin-users'
+import type { NormalizedAdminUser } from '../../../../../packages/auth/src/admin-users'
 import { keys } from './keys'
 
 export const adminUsersOptions = () =>
@@ -16,14 +17,9 @@ export const adminUsersOptions = () =>
 				throw new Error(error.message ?? 'Failed to fetch users')
 			}
 
-			// oxlint-disable-next-line typescript/no-unsafe-type-assertion
-			return data.users as unknown as UserWithRole[]
+			return normalizeAdminUserList(data.users)
 		},
 		queryKey: keys.admin.users.list(),
 	})
 
-export type UserWithRole = Prettify<
-	BetterAuthUserWithRole & {
-		role: AuthRole
-	}
->
+export type UserWithRole = Prettify<NormalizedAdminUser<BetterAuthUserWithRole>>

--- a/apps/web/src/lib/queries/keys.ts
+++ b/apps/web/src/lib/queries/keys.ts
@@ -9,7 +9,7 @@ export const keys = {
 	listings: {
 		all: ['todos'] as const,
 		list: () => [...keys.listings.all, 'list'] as const,
-		one: (id: string) => [...keys.listings.all, 'one', id] as const,
+		one: (id: number) => [...keys.listings.all, 'one', id] as const,
 		search: (query: string) => [...keys.listings.all, 'search', query] as const,
 	},
 } as const

--- a/apps/web/src/lib/queries/listings.queries.ts
+++ b/apps/web/src/lib/queries/listings.queries.ts
@@ -9,7 +9,7 @@ export const getMyListingsOptions = () =>
 		queryKey: keys.listings.list(),
 	})
 
-export const getOneListingOptions = (id: string) =>
+export const getOneListingOptions = (id: number) =>
 	edenQueryOption({
 		edenQuery: eden().listings({ id }).get,
 		queryKey: keys.listings.one(id),

--- a/apps/web/src/lib/server-fn/fetch-auth.ts
+++ b/apps/web/src/lib/server-fn/fetch-auth.ts
@@ -1,8 +1,9 @@
-import type { AuthRole } from '@repo/db/types'
 import { createServerFn } from '@tanstack/react-start'
 import { getRequest } from '@tanstack/react-start/server'
 
 import { authClient } from '~/lib/clients/auth-client'
+
+import { normalizeAuthSession } from '../../../../../packages/auth/src/auth-session'
 
 export const fetchAuth = createServerFn({ method: 'GET' }).handler(async () => {
 	const request = getRequest()
@@ -13,12 +14,5 @@ export const fetchAuth = createServerFn({ method: 'GET' }).handler(async () => {
 		return null
 	}
 
-	return {
-		session: data.session,
-		user: {
-			...data.user,
-			// oxlint-disable-next-line typescript/no-unsafe-type-assertion
-			role: (data.user.role ?? 'user') as AuthRole,
-		},
-	}
+	return normalizeAuthSession(data)
 })

--- a/apps/web/src/routes/_authenticated/listing.$id.tsx
+++ b/apps/web/src/routes/_authenticated/listing.$id.tsx
@@ -1,4 +1,5 @@
 import type { Listing } from '@repo/db/types'
+import { coercePositiveInt } from '@repo/utils'
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, useCanGoBack, useRouter } from '@tanstack/react-router'
 import { ArrowLeft, Calendar, User } from 'lucide-react'
@@ -10,7 +11,7 @@ import { getOneListingOptions } from '~/lib/queries/listings.queries'
 
 export const Route = createFileRoute('/_authenticated/listing/$id')({
 	component: RouteComponent,
-	params: z.object({ id: z.uuidv7() }),
+	params: z.object({ id: positiveIntParam('listing id') }),
 })
 
 function RouteComponent() {
@@ -82,4 +83,18 @@ function ListingDetails({ listing }: { listing: Listing }) {
 			</div>
 		</div>
 	)
+}
+
+function positiveIntParam(label: string) {
+	return z.string().transform((value, ctx) => {
+		try {
+			return coercePositiveInt(value, label)
+		} catch (error) {
+			ctx.addIssue({
+				code: 'custom',
+				message: error instanceof Error ? error.message : `Invalid ${label}: ${value}`,
+			})
+			return z.NEVER
+		}
+	})
 }

--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
         "@repo/db": "workspace:*",
         "@repo/email": "workspace:*",
         "@repo/env": "workspace:*",
+        "@repo/utils": "workspace:*",
         "better-auth": "catalog:",
         "dotenv": "^17.4.2",
       },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -5,6 +5,7 @@
 	"main": "./src/auth-config.ts",
 	"exports": {
 		".": "./src/auth-config.ts",
+		"./admin-users": "./src/admin-users.ts",
 		"./auth-session": "./src/auth-session.ts"
 	},
 	"scripts": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -3,6 +3,10 @@
 	"private": true,
 	"type": "module",
 	"main": "./src/auth-config.ts",
+	"exports": {
+		".": "./src/auth-config.ts",
+		"./auth-session": "./src/auth-session.ts"
+	},
 	"scripts": {
 		"generate": "dotenv -e ../../apps/backend/.env.local -- bunx @better-auth/cli generate --config src/auth-config.ts --output ../db/src/schemas/tmp-auth.ts",
 		"typecheck": "tsgo --noEmit"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -15,6 +15,7 @@
 		"@repo/db": "workspace:*",
 		"@repo/email": "workspace:*",
 		"@repo/env": "workspace:*",
+		"@repo/utils": "workspace:*",
 		"better-auth": "catalog:",
 		"dotenv": "^17.4.2"
 	},

--- a/packages/auth/src/admin-users.ts
+++ b/packages/auth/src/admin-users.ts
@@ -1,0 +1,28 @@
+import { AuthRole } from '@repo/db/types'
+import type { AuthRole as AuthRoleType } from '@repo/db/types'
+
+import { normalizeAuthId, stringifyAuthId } from './auth-session'
+
+type AdminUserLike = {
+	id: number | string
+	role?: string | null
+}
+
+export type NormalizedAdminUser<TUser extends AdminUserLike> = Omit<TUser, 'id' | 'role'> & {
+	id: number
+	role: AuthRoleType
+}
+
+const isAuthRole = (value: string): value is AuthRoleType => AuthRole.some((role) => role === value)
+
+export const normalizeAdminUser = <TUser extends AdminUserLike>(user: TUser) =>
+	({
+		...user,
+		id: normalizeAuthId(user.id),
+		role: user.role && isAuthRole(user.role) ? user.role : 'user',
+	}) satisfies NormalizedAdminUser<TUser>
+
+export const normalizeAdminUserList = <TUser extends AdminUserLike>(users: TUser[]) =>
+	users.map((user) => normalizeAdminUser(user))
+
+export { stringifyAuthId }

--- a/packages/auth/src/auth-config.ts
+++ b/packages/auth/src/auth-config.ts
@@ -14,7 +14,7 @@ export const createAuth = () =>
 			},
 
 			database: {
-				generateId: 'uuid',
+				generateId: 'serial',
 			},
 		},
 

--- a/packages/auth/src/auth-session.ts
+++ b/packages/auth/src/auth-session.ts
@@ -1,5 +1,6 @@
 import { AuthRole } from '@repo/db/types'
 import type { AuthRole as AuthRoleType } from '@repo/db/types'
+import { coercePositiveInt, normalizeOptionalPositiveInt } from '@repo/utils'
 
 type AuthId = number | string
 
@@ -30,18 +31,10 @@ type NormalizedUser<TUser extends AuthUserLike> = Omit<TUser, 'id' | 'role'> & {
 
 const isAuthRole = (value: string): value is AuthRoleType => AuthRole.some((role) => role === value)
 
-export const normalizeAuthId = (value: AuthId) => {
-	const normalized = typeof value === 'number' ? value : Number(value)
-
-	if (!Number.isSafeInteger(normalized) || normalized < 1) {
-		throw new Error(`Invalid auth id: ${value}`)
-	}
-
-	return normalized
-}
+export const normalizeAuthId = (value: AuthId) => coercePositiveInt(value, 'auth id')
 
 export const normalizeOptionalAuthId = (value: AuthId | null | undefined) =>
-	value === null || value === undefined ? value : normalizeAuthId(value)
+	normalizeOptionalPositiveInt(value, 'auth id')
 
 export const normalizeAuthSession = <
 	TSession extends AuthSessionLike,

--- a/packages/auth/src/auth-session.ts
+++ b/packages/auth/src/auth-session.ts
@@ -1,0 +1,64 @@
+import { AuthRole } from '@repo/db/types'
+import type { AuthRole as AuthRoleType } from '@repo/db/types'
+
+type AuthId = number | string
+
+type AuthSessionLike = {
+	id: AuthId
+	impersonatedBy?: AuthId | null
+	userId: AuthId
+}
+
+type AuthUserLike = {
+	id: AuthId
+	role?: string | null
+}
+
+type NormalizedSession<TSession extends AuthSessionLike> = Omit<
+	TSession,
+	'id' | 'impersonatedBy' | 'userId'
+> & {
+	id: number
+	impersonatedBy?: number | null
+	userId: number
+}
+
+type NormalizedUser<TUser extends AuthUserLike> = Omit<TUser, 'id' | 'role'> & {
+	id: number
+	role: AuthRoleType
+}
+
+const isAuthRole = (value: string): value is AuthRoleType => AuthRole.some((role) => role === value)
+
+export const normalizeAuthId = (value: AuthId) => {
+	const normalized = typeof value === 'number' ? value : Number(value)
+
+	if (!Number.isSafeInteger(normalized) || normalized < 1) {
+		throw new Error(`Invalid auth id: ${value}`)
+	}
+
+	return normalized
+}
+
+export const normalizeOptionalAuthId = (value: AuthId | null | undefined) =>
+	value === null || value === undefined ? value : normalizeAuthId(value)
+
+export const normalizeAuthSession = <
+	TSession extends AuthSessionLike,
+	TUser extends AuthUserLike,
+>(auth: {
+	session: TSession
+	user: TUser
+}): { session: NormalizedSession<TSession>; user: NormalizedUser<TUser> } => ({
+	session: {
+		...auth.session,
+		id: normalizeAuthId(auth.session.id),
+		impersonatedBy: normalizeOptionalAuthId(auth.session.impersonatedBy),
+		userId: normalizeAuthId(auth.session.userId),
+	} satisfies NormalizedSession<TSession>,
+	user: {
+		...auth.user,
+		id: normalizeAuthId(auth.user.id),
+		role: auth.user.role && isAuthRole(auth.user.role) ? auth.user.role : 'user',
+	} satisfies NormalizedUser<TUser>,
+})

--- a/packages/auth/src/auth-session.ts
+++ b/packages/auth/src/auth-session.ts
@@ -33,6 +33,8 @@ const isAuthRole = (value: string): value is AuthRoleType => AuthRole.some((role
 
 export const normalizeAuthId = (value: AuthId) => coercePositiveInt(value, 'auth id')
 
+export const stringifyAuthId = (value: AuthId) => String(normalizeAuthId(value))
+
 export const normalizeOptionalAuthId = (value: AuthId | null | undefined) =>
 	normalizeOptionalPositiveInt(value, 'auth id')
 

--- a/packages/db/src/schema-utils.ts
+++ b/packages/db/src/schema-utils.ts
@@ -5,15 +5,18 @@ export const numericId = (name = 'id') => bigint(name, { mode: 'number' })
 
 export const identityId = (name = 'id') => numericId(name).primaryKey().generatedAlwaysAsIdentity()
 
-// oxlint-disable-next-line sort-keys
-export const common = {
-	id: uuid()
-		.primaryKey()
-		.default(sql`uuidv7()`),
-
+export const timestamps = {
 	createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
 	updatedAt: timestamp({ withTimezone: true })
 		.notNull()
 		.defaultNow()
 		.$onUpdate(() => new Date()),
+}
+
+// oxlint-disable-next-line sort-keys
+export const common = {
+	id: uuid()
+		.primaryKey()
+		.default(sql`uuidv7()`),
+	...timestamps,
 }

--- a/packages/db/src/schema-utils.ts
+++ b/packages/db/src/schema-utils.ts
@@ -1,5 +1,9 @@
-import { timestamp, uuid } from 'drizzle-orm/pg-core'
+import { bigint, timestamp, uuid } from 'drizzle-orm/pg-core'
 import { sql } from 'drizzle-orm/sql'
+
+export const numericId = (name = 'id') => bigint(name, { mode: 'number' })
+
+export const identityId = (name = 'id') => numericId(name).primaryKey().generatedAlwaysAsIdentity()
 
 // oxlint-disable-next-line sort-keys
 export const common = {

--- a/packages/db/src/schemas/assets.ts
+++ b/packages/db/src/schemas/assets.ts
@@ -1,7 +1,7 @@
 // oxlint-disable no-inline-comments
-import { integer, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { integer, pgEnum, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 
-import { common } from '../schema-utils'
+import { common, numericId } from '../schema-utils'
 import { users } from './auth'
 
 export const assetStatus = pgEnum('asset_status', [
@@ -15,7 +15,7 @@ export const assets = pgTable('assets', {
 	...common,
 
 	// Ownership
-	ownerId: uuid()
+	ownerId: numericId('owner_id')
 		.references(() => users.id, { onDelete: 'cascade' })
 		.notNull(),
 

--- a/packages/db/src/schemas/assets.ts
+++ b/packages/db/src/schemas/assets.ts
@@ -1,7 +1,7 @@
 // oxlint-disable no-inline-comments
 import { integer, pgEnum, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 
-import { common, numericId } from '../schema-utils'
+import { identityId, numericId, timestamps } from '../schema-utils'
 import { users } from './auth'
 
 export const assetStatus = pgEnum('asset_status', [
@@ -12,7 +12,8 @@ export const assetStatus = pgEnum('asset_status', [
 ])
 
 export const assets = pgTable('assets', {
-	...common,
+	id: identityId(),
+	...timestamps,
 
 	// Ownership
 	ownerId: numericId('owner_id')

--- a/packages/db/src/schemas/auth.ts
+++ b/packages/db/src/schemas/auth.ts
@@ -1,14 +1,14 @@
 // oxlint-disable no-inline-comments
-import { boolean, index, pgSchema, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { boolean, index, pgSchema, text, timestamp } from 'drizzle-orm/pg-core'
 
-import { common } from '../schema-utils'
+import { identityId, numericId } from '../schema-utils'
 
 export const authSchema = pgSchema('auth')
 
 export const authRoles = authSchema.enum('roles', ['admin', 'user'])
 
 export const users = authSchema.table('users', {
-	id: common.id,
+	id: identityId(),
 	name: text('name').notNull(),
 	email: text('email').notNull().unique(),
 	emailVerified: boolean('email_verified').default(false).notNull(),
@@ -27,7 +27,7 @@ export const users = authSchema.table('users', {
 export const sessions = authSchema.table(
 	'sessions',
 	{
-		id: common.id,
+		id: identityId(),
 		expiresAt: timestamp('expires_at').notNull(),
 		token: text('token').notNull().unique(),
 		createdAt: timestamp('created_at').defaultNow().notNull(),
@@ -36,7 +36,7 @@ export const sessions = authSchema.table(
 			.notNull(),
 		ipAddress: text('ip_address'),
 		userAgent: text('user_agent'),
-		userId: uuid('user_id')
+		userId: numericId('user_id')
 			.notNull()
 			.references(() => users.id, { onDelete: 'cascade' }),
 		impersonatedBy: text('impersonated_by'),
@@ -47,10 +47,10 @@ export const sessions = authSchema.table(
 export const accounts = authSchema.table(
 	'accounts',
 	{
-		id: common.id,
+		id: identityId(),
 		accountId: text('account_id').notNull(),
 		providerId: text('provider_id').notNull(),
-		userId: uuid('user_id')
+		userId: numericId('user_id')
 			.notNull()
 			.references(() => users.id, { onDelete: 'cascade' }),
 		accessToken: text('access_token'),
@@ -71,7 +71,7 @@ export const accounts = authSchema.table(
 export const verifications = authSchema.table(
 	'verifications',
 	{
-		id: common.id,
+		id: identityId(),
 		identifier: text('identifier').notNull(),
 		value: text('value').notNull(),
 		expiresAt: timestamp('expires_at').notNull(),

--- a/packages/db/src/schemas/listings.ts
+++ b/packages/db/src/schemas/listings.ts
@@ -1,12 +1,12 @@
 import { integer, pgTable, primaryKey, text, uuid } from 'drizzle-orm/pg-core'
 
-import { common } from '../schema-utils'
+import { common, numericId } from '../schema-utils'
 import { assets } from './assets'
 import { users } from './auth'
 
 export const listings = pgTable('listings', {
 	...common,
-	userId: uuid()
+	userId: numericId('user_id')
 		.references(() => users.id, { onDelete: 'cascade' })
 		.notNull(),
 

--- a/packages/db/src/schemas/listings.ts
+++ b/packages/db/src/schemas/listings.ts
@@ -1,4 +1,4 @@
-import { integer, pgTable, primaryKey, text, uuid } from 'drizzle-orm/pg-core'
+import { integer, pgTable, primaryKey, text } from 'drizzle-orm/pg-core'
 
 import { identityId, numericId, timestamps } from '../schema-utils'
 import { assets } from './assets'
@@ -22,7 +22,7 @@ export const listingImages = pgTable(
 		listingId: numericId('listing_id')
 			.references(() => listings.id, { onDelete: 'cascade' })
 			.notNull(),
-		assetId: uuid()
+		assetId: numericId('asset_id')
 			.references(() => assets.id, { onDelete: 'cascade' })
 			.notNull(),
 		sortOrder: integer().notNull().default(0),

--- a/packages/db/src/schemas/listings.ts
+++ b/packages/db/src/schemas/listings.ts
@@ -1,11 +1,12 @@
 import { integer, pgTable, primaryKey, text, uuid } from 'drizzle-orm/pg-core'
 
-import { common, numericId } from '../schema-utils'
+import { identityId, numericId, timestamps } from '../schema-utils'
 import { assets } from './assets'
 import { users } from './auth'
 
 export const listings = pgTable('listings', {
-	...common,
+	id: identityId(),
+	...timestamps,
 	userId: numericId('user_id')
 		.references(() => users.id, { onDelete: 'cascade' })
 		.notNull(),
@@ -18,7 +19,7 @@ export const listings = pgTable('listings', {
 export const listingImages = pgTable(
 	'listing_images',
 	{
-		listingId: uuid()
+		listingId: numericId('listing_id')
 			.references(() => listings.id, { onDelete: 'cascade' })
 			.notNull(),
 		assetId: uuid()

--- a/packages/db/src/schemas/roles.ts
+++ b/packages/db/src/schemas/roles.ts
@@ -1,6 +1,6 @@
-import { pgEnum, pgTable, unique, uuid } from 'drizzle-orm/pg-core'
+import { pgEnum, pgTable, unique } from 'drizzle-orm/pg-core'
 
-import { common } from '../schema-utils'
+import { common, numericId } from '../schema-utils'
 import { users } from './auth'
 
 export const roles = pgEnum('roles', ['superadmin', 'admin', 'user'])
@@ -9,11 +9,11 @@ export const userRoles = pgTable(
 	'user_roles',
 	{
 		...common,
-		userId: uuid()
+		userId: numericId('user_id')
 			.references(() => users.id, { onDelete: 'cascade' })
 			.notNull(),
 		role: roles().notNull(),
-		grantedById: uuid().references(() => users.id, { onDelete: 'set null' }),
+		grantedById: numericId('granted_by_id').references(() => users.id, { onDelete: 'set null' }),
 	},
 	(table) => [unique('user_roles_userId_role_unique').on(table.userId, table.role)]
 )

--- a/packages/db/src/test-mock.ts
+++ b/packages/db/src/test-mock.ts
@@ -13,6 +13,10 @@ export const createTestDb = async () => {
 		// oxlint-disable-next-line typescript/consistent-type-imports, typescript/no-unsafe-type-assertion
 		require('drizzle-kit/api-postgres') as typeof import('drizzle-kit/api-postgres')
 
+	await db.execute(sql`DROP SCHEMA IF EXISTS auth CASCADE`)
+	await db.execute(sql`DROP SCHEMA IF EXISTS public CASCADE`)
+	await db.execute(sql`CREATE SCHEMA public`)
+
 	// oxlint-disable-next-line typescript/no-explicit-any, typescript/no-unsafe-argument, typescript/no-unsafe-type-assertion
 	const { apply } = await pushSchema(schema, db as any, 'snake_case')
 	await apply()
@@ -29,7 +33,7 @@ export const truncateAllTables = async (instance: Awaited<ReturnType<typeof crea
 	const tables = await instance.execute<{ tablename: string; schemaname: string }>(sql`
     SELECT schemaname, tablename 
     FROM pg_tables 
-    WHERE schemaname = 'public' -- OR schemaname = 'auth'
+    WHERE schemaname IN ('auth', 'public')
     AND tablename NOT IN ('schema_migrations', '__drizzle_migrations')
   `)
 

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -6,8 +6,6 @@ import { authRoles } from './schemas/auth'
 import type { accounts, sessions, users, verifications } from './schemas/auth'
 import { listingImages, listings } from './schemas/listings'
 
-const omits = { createdAt: true, id: true, updatedAt: true } as const
-
 // auth.ts
 export const AuthRole = [...authRoles.enumValues] as const
 export type AuthRole = (typeof AuthRole)[number]
@@ -48,7 +46,7 @@ export const listingSchema = createSelectSchema(listings)
 export const listingInsertSchema = createInsertSchema(listings, {
 	description: (s) => s.nonempty(),
 	title: (s) => s.nonempty(),
-}).omit({ ...omits, userId: true })
+}).omit({ createdAt: true, updatedAt: true, userId: true })
 export const listingUpdateSchema = listingInsertSchema.partial()
 
 export type ListingImage = typeof listingImages.$inferSelect

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from './constants'
+export * from './numeric-id'
 export * from './try-catch'
 export type * from './type-utils'
 export * from './typed-object'

--- a/packages/utils/src/numeric-id.ts
+++ b/packages/utils/src/numeric-id.ts
@@ -1,0 +1,16 @@
+type NumericId = number | string
+
+export const coercePositiveInt = (value: NumericId, label = 'value') => {
+	const normalized = typeof value === 'number' ? value : Number(value)
+
+	if (!Number.isSafeInteger(normalized) || normalized < 1) {
+		throw new Error(`Invalid ${label}: ${value}`)
+	}
+
+	return normalized
+}
+
+export const normalizeOptionalPositiveInt = (
+	value: NumericId | null | undefined,
+	label = 'value'
+) => (value === null || value === undefined ? value : coercePositiveInt(value, label))

--- a/packages/utils/src/numeric-id.ts
+++ b/packages/utils/src/numeric-id.ts
@@ -1,13 +1,25 @@
 type NumericId = number | string
 
 export const coercePositiveInt = (value: NumericId, label = 'value') => {
-	const normalized = typeof value === 'number' ? value : Number(value)
+	if (typeof value === 'string') {
+		if (!/^\d+$/.test(value)) {
+			throw new Error(`Invalid ${label}: ${value}`)
+		}
 
-	if (!Number.isSafeInteger(normalized) || normalized < 1) {
+		const normalized = Number(value)
+
+		if (!Number.isSafeInteger(normalized) || normalized < 1) {
+			throw new Error(`Invalid ${label}: ${value}`)
+		}
+
+		return normalized
+	}
+
+	if (!Number.isSafeInteger(value) || value < 1) {
 		throw new Error(`Invalid ${label}: ${value}`)
 	}
 
-	return normalized
+	return value
 }
 
 export const normalizeOptionalPositiveInt = (


### PR DESCRIPTION
## Summary
- replace UUID relational database identifiers with bigint identity-backed numeric IDs across auth, listings, assets, and roles
- normalize numeric IDs at auth, admin, and routing boundaries so app code works with `number` consistently while Better Auth integration points keep their required string conversions
- extend server tests to cover numeric ID coercion, auth normalization, admin flows, listings, file ownership, and asset lifecycle behavior

## Verification
- `bun typecheck`
- `bun -F @repo/server test`

## Closes
Closes #23
Closes #24
Closes #25
Closes #26
Closes #27
Closes #28
Closes #29
